### PR TITLE
Add package.json to make install easier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "comicchat",
+  "version": "0.0.1",
+  "description": "a web version of comicchat",
+  "main": "server/server.js",
+  "dependencies": {
+    "websocket": "~1.0.22"
+  },
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gyng/comicchat.git"
+  },
+  "author": "",
+  "license": "",
+  "bugs": {
+    "url": "https://github.com/gyng/comicchat/issues"
+  }
+}


### PR DESCRIPTION
This patch adds a package.json to make installing dependencies of the
package easier. Two fiels are still left blank and need to be filled,
the author and the license field. For more info on package.json files see [here](https://docs.npmjs.com/files/package.json)

P.S.: do you have a license for this project? I want to adjust it a bit to fit my needs...
